### PR TITLE
feat: add Maritaca AI provider support

### DIFF
--- a/switch-provider/src/config/settings.rs
+++ b/switch-provider/src/config/settings.rs
@@ -100,6 +100,9 @@ impl Settings {
         if base_url.contains("openai.com") {
             return Some(ProviderType::OpenAI);
         }
+        if base_url.contains("maritaca.ai") {
+            return Some(ProviderType::MaritacaAI);
+        }
 
         Some(ProviderType::Custom)
     }
@@ -228,6 +231,7 @@ pub enum ProviderType {
     ZAI,
     GoogleAI,
     OpenAI,
+    MaritacaAI,
     Custom,
 }
 
@@ -243,6 +247,7 @@ impl ProviderType {
             ProviderType::ZAI => Some("https://api.z.ai/api/anthropic"),
             ProviderType::GoogleAI => Some("https://generativelanguage.googleapis.com"),
             ProviderType::OpenAI => Some("https://api.openai.com/v1"),
+            ProviderType::MaritacaAI => Some("https://chat.maritaca.ai/api"),
             ProviderType::Custom => None,
         }
     }
@@ -258,6 +263,7 @@ impl ProviderType {
             ProviderType::ZAI => Some("GLM-4.7"),
             ProviderType::GoogleAI => Some("gemini-2.0-flash"),
             ProviderType::OpenAI => Some("gpt-4o-mini"),
+            ProviderType::MaritacaAI => Some("sabia-4"),
             ProviderType::Custom => None,
         }
     }
@@ -291,6 +297,7 @@ impl ProviderType {
             ProviderType::ZAI => "Z.AI",
             ProviderType::GoogleAI => "Google AI",
             ProviderType::OpenAI => "OpenAI",
+            ProviderType::MaritacaAI => "Maritaca AI",
             ProviderType::Custom => "Custom",
         }
     }
@@ -394,6 +401,7 @@ mod tests {
         assert!(ProviderType::OpenCodeGo.needs_model_selection());
         assert!(!ProviderType::Anthropic.needs_model_selection());
         assert!(!ProviderType::GoogleAI.needs_model_selection());
+        assert!(!ProviderType::MaritacaAI.needs_model_selection());
     }
 
     #[test]
@@ -421,5 +429,35 @@ mod tests {
         assert!(settings.normalize_activation_model());
         assert_eq!(settings.model(), Some("MiniMax-M2.7"));
         assert_eq!(settings.env.sonnet_model.as_deref(), Some("MiniMax-M2.7"));
+    }
+
+    #[test]
+    fn test_maritaca_settings() {
+        let settings = Settings::with_base_url(
+            "https://chat.maritaca.ai/api".to_string(),
+            "my-maritaca-key".to_string(),
+            "sabia-4".to_string(),
+        );
+        assert_eq!(settings.env.base_url, Some("https://chat.maritaca.ai/api".to_string()));
+        assert_eq!(settings.env.model, Some("sabia-4".to_string()));
+        assert_eq!(settings.provider_type(), Some(ProviderType::MaritacaAI));
+    }
+
+    #[test]
+    fn test_maritaca_default_model() {
+        assert_eq!(ProviderType::MaritacaAI.default_model(), Some("sabia-4"));
+    }
+
+    #[test]
+    fn test_maritaca_endpoint() {
+        assert_eq!(
+            ProviderType::MaritacaAI.endpoint(),
+            Some("https://chat.maritaca.ai/api")
+        );
+    }
+
+    #[test]
+    fn test_maritaca_display_name() {
+        assert_eq!(ProviderType::MaritacaAI.display_name(), "Maritaca AI");
     }
 }

--- a/switch-provider/src/main.rs
+++ b/switch-provider/src/main.rs
@@ -41,6 +41,7 @@ fn provider_type_from_index(index: i32) -> Option<config::ProviderType> {
         7 => Some(config::ProviderType::Custom),
         8 => Some(config::ProviderType::OpenCodeZen),
         9 => Some(config::ProviderType::OpenCodeGo),
+        10 => Some(config::ProviderType::MaritacaAI),
         _ => None,
     }
 }

--- a/switch-provider/ui/appwindow.slint
+++ b/switch-provider/ui/appwindow.slint
@@ -207,6 +207,9 @@ export component AppWindow inherits Window {
                 Row {
                     Button { text: "OpenCode Zen"; height: 34px; clicked => { root.selected-endpoint = 8; root.add-step = 2; root.available-models = []; root.filtered-models = []; root.model-filter = ""; root.new-model-name = ""; } }
                     Button { text: "OpenCode Go"; height: 34px; clicked => { root.selected-endpoint = 9; root.add-step = 2; root.available-models = []; root.filtered-models = []; root.model-filter = ""; root.new-model-name = ""; } }
+                    Button { text: "Maritaca AI"; height: 34px; clicked => { root.selected-endpoint = 10; root.add-step = 2; } }
+                }
+                Row {
                     Button { text: "Custom"; height: 34px; clicked => { root.selected-endpoint = 7; root.add-step = 2; } }
                 }
             }
@@ -320,14 +323,15 @@ export component AppWindow inherits Window {
             spacing: 14px;
             Text { text: "Confirmar Provider"; font-size: 24px; font-weight: 800; color: #ffffff; }
             Rectangle {
-                height: 118px;
+                height: 134px;
                 background: #2d2d2d;
                 border-radius: 8px;
                 VerticalBox {
                     padding: 12px;
                     spacing: 4px;
                     Text { text: "Nome: " + root.new-provider-name; font-size: 17px; font-weight: 600; color: #ffffff; overflow: elide; }
-                    Text { text: "Tipo: " + (root.selected-endpoint == 1 ? "MiniMax" : root.selected-endpoint == 2 ? "OpenRouter" : root.selected-endpoint == 3 ? "Anthropic" : root.selected-endpoint == 4 ? "Z.AI" : root.selected-endpoint == 5 ? "Google AI" : root.selected-endpoint == 6 ? "OpenAI" : root.selected-endpoint == 8 ? "OpenCode Zen" : root.selected-endpoint == 9 ? "OpenCode Go" : "Custom"); font-size: 15px; color: #6699ff; }
+                    Text { text: "Tipo: " + (root.selected-endpoint == 1 ? "MiniMax" : root.selected-endpoint == 2 ? "OpenRouter" : root.selected-endpoint == 3 ? "Anthropic" : root.selected-endpoint == 4 ? "Z.AI" : root.selected-endpoint == 5 ? "Google AI" : root.selected-endpoint == 6 ? "OpenAI" : root.selected-endpoint == 8 ? "OpenCode Zen" : root.selected-endpoint == 9 ? "OpenCode Go" : root.selected-endpoint == 10 ? "Maritaca AI" : "Custom"); font-size: 15px; color: #6699ff; }
+                    if root.selected-endpoint == 10: Text { text: "Modelo padrao: sabia-4"; font-size: 13px; color: #aaaaaa; overflow: elide; }
                     if root.selected-endpoint == 2 || root.selected-endpoint == 8 || root.selected-endpoint == 9: Text { text: "Modelo: " + root.new-model-name; font-size: 13px; color: #aaaaaa; overflow: elide; }
                     Text { text: "API Key: [oculta]"; font-size: 13px; color: #888888; }
                 }


### PR DESCRIPTION
## Summary

Adds [Maritaca AI](https://www.maritaca.ai) (Sabiá models) as a provider option.

## Changes

- **`src/config/settings.rs`**: Added `MaritacaAI` to `ProviderType` enum with endpoint `https://chat.maritaca.ai/api`, default model `sabia-4`, URL detection, display name, and tests
- **`src/main.rs`**: Added mapping `10 => ProviderType::MaritacaAI`
- **`ui/appwindow.slint`**: Added "Maritaca AI" button (index 10) and type label in confirm step

## Checklist

- [ ] Testar localmente antes de merge